### PR TITLE
feat(domain): Add feature-flagged serde impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,7 @@ name = "domain"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "serde",
  "uuid",
 ]
 
@@ -530,7 +531,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -980,7 +993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1244,7 +1257,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1759,7 +1772,7 @@ checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1968,11 +1981,12 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.1",
+ "serde",
 ]
 
 [[package]]
@@ -1992,6 +2006,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasite"
@@ -2219,6 +2242,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "write16"

--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -4,5 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-uuid = { version = "1.12.1", features = ["v7"] }
+uuid = { version = "1.13.1", features = ["v7"] }
 chrono = "0.4.39"
+serde = { version = "1.0.217", features = ["derive"], optional = true }
+
+[features]
+default = []
+serde = ["dep:serde", "uuid/serde"]

--- a/domain/src/offering.rs
+++ b/domain/src/offering.rs
@@ -7,6 +7,8 @@ use uuid::Uuid;
 /// [Vendor]: crate::vendor::Vendor
 /// [Customer]: crate::customer::Customer
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "kind"))]
 pub enum Offering {
     Rental(Rental),
     Tour(Tour),
@@ -14,11 +16,14 @@ pub enum Offering {
 
 /// A unique identifier for an [Offering].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct OfferingId(pub Uuid);
 
 /// An [Offering] for an equipment rental.
 /// It may be either a child of a [Tour] or an offering in its own right.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rental {
     pub id: OfferingId,
     pub vendor: VendorId,
@@ -28,6 +33,7 @@ pub struct Rental {
 /// An [Offering] for a scheduled experience.
 /// It may be guided or self-guided.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Tour {
     pub id: OfferingId,
     pub vendor: VendorId,
@@ -38,6 +44,8 @@ pub struct Tour {
 
 /// The style/modality of a [Tour].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(variant_identifier))]
 pub enum TourStyle {
     Guided = 1,
     SelfGuided = 2,
@@ -54,7 +62,8 @@ impl Display for TourStyle {
 
 /// A child-rental of a [Tour], backed by an underlying [Rental].
 #[derive(Debug, Clone)]
-struct TourRental {
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TourRental {
     pub id: OfferingId,
     pub name: String,
 }

--- a/domain/src/user.rs
+++ b/domain/src/user.rs
@@ -9,6 +9,8 @@ pub struct User {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct UserId(pub Uuid);
 
 impl UserId {
@@ -24,10 +26,16 @@ impl Default for UserId {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Username(pub String);
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Password(pub String);
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct EmailAddress(pub String);

--- a/domain/src/vendor.rs
+++ b/domain/src/vendor.rs
@@ -5,12 +5,15 @@
 /// [Customer]: crate::customer::Customer
 /// [Booking]: crate::booking::Booking
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Vendor {
     pub id: VendorId,
     pub name: String,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct VendorId(pub uuid::Uuid);
 
 impl VendorId {


### PR DESCRIPTION
A pure domain generally does not give consideration to transport/serialization protocols. These changes make a concession by providing serde serialize/deserialize implementations for domain types behind a 'serde' feature flag.

The expectation is that consumers (i.e., application, server, etc.) should define their own "view" types instead of depending on domain's serialization format, but this provides a way to e.g., deserialize domain types from json aggregates from SQL queries in infrastructure.